### PR TITLE
build: improve `emptyModulesPlugin` with `es-module-lexer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pnpm preview
 
 # release
 pnpm build
-pnpm release
+pnpm release-production
 
 # migration on D1
 pnpm migrate-production status

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@vavite/connect": "^1.8.1",
     "@vitejs/plugin-react": "^4.0.2",
     "consola": "^3.2.3",
+    "es-module-lexer": "^1.3.0",
     "esbuild": "^0.18.11",
     "prettier": "^3.0.0",
     "react-hot-toast": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ devDependencies:
   consola:
     specifier: ^3.2.3
     version: 3.2.3
+  es-module-lexer:
+    specifier: ^1.3.0
+    version: 1.3.0
   esbuild:
     specifier: ^0.18.11
     version: 0.18.11
@@ -1902,6 +1905,10 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+    dev: true
+
+  /es-module-lexer@1.3.0:
+    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
     dev: true
 
   /esbuild@0.16.3:

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import React from "react";
 import { Toaster } from "react-hot-toast";
 import { rpcClient } from "../rpc/client";
-import serverOnly from "../server-only";
+import { rpcRoutes } from "../rpc/server";
 
 export function Page() {
   return (
@@ -66,7 +66,7 @@ function useCounterKV() {
   const getCounterQuery = useQuery({
     queryKey,
     queryFn: import.meta.env.SSR
-      ? serverOnly.rpcRoutes.getCounterKV
+      ? rpcRoutes.getCounterKV
       : rpcClient.getCounterKV,
     suspense: import.meta.env.SSR,
   });
@@ -87,7 +87,7 @@ function useCounterD1() {
   const getCounterQuery = useQuery({
     queryKey,
     queryFn: import.meta.env.SSR
-      ? serverOnly.rpcRoutes.getCounterD1
+      ? rpcRoutes.getCounterD1
       : rpcClient.getCounterD1,
     suspense: import.meta.env.SSR,
   });

--- a/src/server-only.ts
+++ b/src/server-only.ts
@@ -1,9 +1,0 @@
-import { rpcRoutes } from "./rpc/server";
-
-// cf. emptyModulesPlugin in vite.config.ts
-
-const serverOnly = {
-  rpcRoutes,
-};
-
-export default serverOnly;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,15 @@ import process from "node:process";
 import importIndexHtmlPlugin from "@hiogawa/vite-import-index-html";
 import vaviteConnect from "@vavite/connect";
 import react from "@vitejs/plugin-react";
+import * as esModuleLexer from "es-module-lexer";
 import unocss from "unocss/vite";
 import { type Plugin, defineConfig } from "vite";
 
 export default defineConfig((ctx) => ({
   plugins: [
-    emptyModulesPlugin(),
+    emptyModulesPlugin({
+      serverOnly: [path.join(process.cwd(), "src/rpc/server.ts")],
+    }),
     react(),
     unocss(),
     importIndexHtmlPlugin(),
@@ -31,14 +34,26 @@ export default defineConfig((ctx) => ({
   clearScreen: false,
 }));
 
-function emptyModulesPlugin(): Plugin {
-  const serverOnlyPath = path.join(process.cwd(), "/src/server-only.ts");
+// similar to https://github.com/remix-run/remix/blob/80c6842f547b7e83b58f1963894b07ad18c2dfe2/packages/remix-dev/compiler/plugins/emptyModules.ts#L10
+// but vite needs to fake esm exports
+function emptyModulesPlugin(opts: { serverOnly: string[] }): Plugin {
   return {
     name: emptyModulesPlugin.name,
     enforce: "pre",
-    transform(_code, id, options) {
-      if (!options?.ssr && id === serverOnlyPath) {
-        return `export default {}`;
+
+    // (ab)use this hook to do async init
+    async configResolved(_config) {
+      await esModuleLexer.init;
+    },
+
+    transform(code, id, transformOpts) {
+      if (!transformOpts?.ssr && opts.serverOnly.includes(id)) {
+        const [_import, exports] = esModuleLexer.parse(code);
+        return exports
+          .map((e) =>
+            e.n === "default" ? `export default {}` : `export var ${e.n} = {}`,
+          )
+          .join("\n");
       }
       return undefined;
     },


### PR DESCRIPTION
I've been wanted to experiment with `es-module-lexer` and this seems to be a nice use case.

Here is how it would look like on client.

![image](https://github.com/hi-ogawa/cloudflare-workers-example/assets/4232207/24541843-3bb0-4374-98c1-58d155ef045d)
